### PR TITLE
Updates to make FastChat easier to run

### DIFF
--- a/recipes/ai-fastchat-amx-ubuntu/README.md
+++ b/recipes/ai-fastchat-amx-ubuntu/README.md
@@ -4,12 +4,14 @@ This demo demonstrates the speedup in Large Language Model CPU inference from 3r
 # Running the Recipe
 The easiest way to run this recipe is using [Intel® Cloud Optimization Modules for Terraform](https://github.com/intel/terraform-intel-gcp-vm/tree/main/examples/gcp-linux-fastchat)
 
+Alternatively, a single node can be running using ansible-pull with the recipe.yml, as described in the main README
+
 # Running the Demo
 SSH into your VM from the cloud console. Wait for a few minutes to ensure that the recipe has run completely. 
 
-Ssh into the c3 instance and run
+Ssh into the newly created C3 instance and run
 
-`python3 -m fastchat.serve.gradio_web_server_multi --share` 
+`source /usr/local/bin/run_demo.sh` 
 
 --- KNOWN ISSUE ---
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
@@ -45,6 +45,6 @@
   hosts: localhost
   connection: local
   tasks:
-    - name: Start web controller shell
+    - name: Start worker
       shell: nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --controller-address http://{{ controller_ip }}:21001 --worker-address http://{{ worker_ip }}:21002 --host {{ worker_ip }} --model-name {{ model_name | default('xeon_3_fastchat') }} </dev/null >/dev/null 2>&1 &
     

--- a/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
@@ -22,7 +22,7 @@
   tasks:
     - name: Install fschat
       pip:
-        name: fschat
+        name: fschat==0.2.18
         state: present
         executable: pip3
     - name: Install plotly

--- a/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe-worker.yml
@@ -13,7 +13,7 @@
       copy:
         dest: "/var/cmd"
         content: |
-          python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --controller-address http://{{ c3_ip }}:21001 --worker-address http://{{ own_ip }}:21002 --host {{ own_ip }} --model-name xeon-3 </dev/null >/dev/null 2>&1 &
+          python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --controller-address http://{{ controller_ip }}:21001 --worker-address http://{{ worker_ip }}:21002 --host {{ worker_ip }} --model-name {{ model_name | default('xeon_3_fastchat') }} </dev/null >/dev/null 2>&1 &
         mode: a+x
 
 - name: Install fschat with pip
@@ -46,5 +46,5 @@
   connection: local
   tasks:
     - name: Start web controller shell
-      shell: nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --controller-address http://{{ c3_ip }}:21001 --worker-address http://{{ own_ip }}:21002 --host {{ own_ip }} --model-name xeon-3 </dev/null >/dev/null 2>&1 & 
+      shell: nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --controller-address http://{{ controller_ip }}:21001 --worker-address http://{{ worker_ip }}:21002 --host {{ worker_ip }} --model-name {{ model_name | default('xeon_3_fastchat') }} </dev/null >/dev/null 2>&1 &
     

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -51,8 +51,8 @@
         dest: "{{ script_dest }}/run_demo.sh"
         content: |
           #!/bin/bash
-          pip install gradio==3.10 -q
-          pip install gradio==3.35.2 -q
+          pip install -qqq gradio==3.10 
+          pip install -qqq gradio==3.35.2
           python3 -m fastchat.serve.gradio_web_server_multi --share
         mode: a+x
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -40,20 +40,5 @@
     - name: Serve Falcon on CPU
       shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
 
-- name: Fix broken gradio 
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Run server
-      shell: nohup python3 -m fastchat.serve.gradio_web_server_multi --share
-    - name: downgrade gradio
-      pip:
-        name: gradio==3.10
-        state: present
-        executable: pip3
-    - name: upgrade gradio
-      pip:
-        name: gradio==3.35.2
-        state: present
-        executable: pip3
+
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -16,7 +16,7 @@
   tasks:
     - name: Install fschat
       pip:
-        name: fschat
+        name: fschat==0.2.18
         state: present
         executable: pip3
     - name: Install plotly

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,7 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port | default('21004') }} --worker-address http://localhost:{{ port | default('21004') }} </dev/null >/dev/null 2>&1 & 
 
 - name: Create script to run gradio frontend
   hosts: localhost

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,7 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default(lmsys/fastchat-t5-3b-v1.0) }} --device cpu --model-name {{ model_name | default(xeon_4_fastchat) }} --port {{ port | default(21004) }} --worker-address http://localhost:{{ port | default(21004) }} </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port | default('21004') }} --worker-address http://localhost:{{ port | default('21004') }} </dev/null >/dev/null 2>&1 & 
 
 - name: Fix broken gradio 
   hosts: localhost

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,7 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port | default('21004') }} --worker-address http://localhost:{{ port | default('21004') }} </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device {{ device_type | default('cpu') }} --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port | default('21004') }} --worker-address http://localhost:{{ port | default('21004') }} </dev/null >/dev/null 2>&1 & 
 
 - name: Create script to run gradio frontend
   hosts: localhost

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -51,8 +51,8 @@
         dest: "{{ script_dest }}/run_demo.sh"
         content: |
           #!/bin/bash
-          pip install -qqq gradio==3.10 
-          pip install -qqq gradio==3.35.2
+          pip install -qqq gradio==3.10 > /dev/null
+          pip install -qqq gradio==3.35.2 > /dev/null
           python3 -m fastchat.serve.gradio_web_server_multi --share
         mode: a+x
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,8 +38,22 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      #shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --model-name xeon_4_fastchat --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port_number | default('21004') }} --worker-address http://localhost:{{ port_number | default('21004') }} </dev/null >/dev/null 2>&1 & 
 
+- name: Create script to run gradio frontend
+  hosts: localhost
+  connection: local
+  vars:
+    script_dest: /usr/local/bin
+  tasks:
+    - name: Add script to run demo to bin
+      copy:
+        dest: "{{ script_dest }}/run_demo.sh"
+        content: |
+          #!/bin/bash
+          pip install gradio==3.10
+          pip install gradio==3.35.2
+          python3 -m fastchat.serve.gradio_web_server_multi --share
+        mode: a+x
 
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,7 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port_number | default('21004') }} --worker-address http://localhost:{{ port_number | default('21004') }} </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
 
 - name: Create script to run gradio frontend
   hosts: localhost
@@ -51,8 +51,8 @@
         dest: "{{ script_dest }}/run_demo.sh"
         content: |
           #!/bin/bash
-          pip install gradio==3.10
-          pip install gradio==3.35.2
+          pip install gradio==3.10 -q
+          pip install gradio==3.35.2 -q
           python3 -m fastchat.serve.gradio_web_server_multi --share
         mode: a+x
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,7 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port {{ port | default('21004') }} --worker-address http://localhost:{{ port | default('21004') }} </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
 
 - name: Fix broken gradio 
   hosts: localhost

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,7 +38,9 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --model-name xeon_4_fastchat --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+
+      #shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
 
 
 

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -35,11 +35,10 @@
   hosts: localhost
   connection: local
   tasks:
-  
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu  --model-name xeon-4 --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default(lmsys/fastchat-t5-3b-v1.0) }} --device cpu --model-name {{ model_name | default(xeon_4_fastchat) }} --port {{ port | default(21004) }} --worker-address http://localhost:{{ port | default(21004) }} </dev/null >/dev/null 2>&1 & 
 
 - name: Fix broken gradio 
   hosts: localhost

--- a/recipes/ai-fastchat-amx-ubuntu/recipe.yml
+++ b/recipes/ai-fastchat-amx-ubuntu/recipe.yml
@@ -38,9 +38,8 @@
     - name: Start web controller shell
       shell: nohup python3 -m fastchat.serve.controller --host 0.0.0.0 </dev/null >/dev/null 2>&1 & 
     - name: Serve Falcon on CPU
-      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --model-name xeon_4_fastchat --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
-
-      #shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      #shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path lmsys/fastchat-t5-3b-v1.0 --device cpu --model-name xeon_4_fastchat --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
+      shell: sleep 10 & nohup python3 -m fastchat.serve.model_worker --model-path {{ model_path | default('lmsys/fastchat-t5-3b-v1.0') }} --device cpu --model-name {{ model_name | default('xeon_4_fastchat') }} --port 21004 --worker-address http://localhost:21004 </dev/null >/dev/null 2>&1 & 
 
 
 


### PR DESCRIPTION
- change the way the templates work, allowing more customizability (need to document)
- make single node running straightforward (just run recipe.yml)