### PR TITLE
Enable base Habana Gaudi Recipe

### DIFF
--- a/recipes/ai-gaudi-ubuntu/README.md
+++ b/recipes/ai-gaudi-ubuntu/README.md
@@ -10,8 +10,8 @@
 | :----- | :---------------------------------------------------------- |
 | Recipe | **Gaudi on Ubuntu** |
 Demo | Setups environment to run Gaudi Demos |  [LINK](TBD)
-| Install time | 12 minutes |
-| Logs | `tail -f /var/ansible-log`|
+| Install time | 15 minutes |
+| Logs | `tail -f /var/log/syslog`|
 
 ## Prerequisites
 
@@ -29,7 +29,6 @@ There are two main usage options:
 ### Option 1 - The simplest way to implement the recipe is with Intel Cloud Modules
 
 [**AWS - Intel® Optimized Cloud Modules for HashiCorp Terraform example**](https://github.com/intel/terraform-intel-aws-vm/tree/main/examples/gen-ai-gaudi-demo)
-
 
 ### Option 2 - Running Ansible manually via the Operating System command line
 
@@ -51,7 +50,7 @@ sudo apt install ansible -y
 #Run ansible-pull
 sudo ansible-pull -vv -U https://github.com/intel/optimized-cloud-recipes.git recipes/ai-gaudi-ubuntu/recipe.yml
 
-# Logs at 'tail -f 10 /var/ansible-log'
+# Logs at 'tail -f 10 /var/log/syslog'
 ```
 
 ## Running the Demo

--- a/recipes/ai-gaudi-ubuntu/README.md
+++ b/recipes/ai-gaudi-ubuntu/README.md
@@ -1,0 +1,71 @@
+<p align="center">
+  <img src="https://github.com/intel/optimized-cloud-recipes/blob/main/images/logo-classicblue-800px.png?raw=true" alt="Intel Logo" width="250"/>
+</p>
+
+# Intel® Optimized Cloud Recipes  - Intel® Gaudi® on Ubuntu
+
+## Overview
+
+| Area   | Description                                                 |
+| :----- | :---------------------------------------------------------- |
+| Recipe | **Gaudi on Ubuntu** |
+Demo | Setups environment to run Gaudi Demos |  [LINK](TBD)
+| Install time | 12 minutes |
+| Logs | `tail -f /var/ansible-log`|
+
+## Prerequisites
+
+| Optimized for | Description                              |
+| :------------ | :--------------------------------------- |
+| OS            | Ubuntu* 22.04 LTS or newer               |
+| Hardware      | Intel® Gaudi® AI Accelerator |
+
+**Note: Only AWS DL1 Instances are supported**
+
+## Usage
+
+There are two main usage options:
+
+### Option 1 - The simplest way to implement the recipe is with Intel Cloud Modules
+
+[**AWS - Intel® Optimized Cloud Modules for HashiCorp Terraform example**](https://github.com/intel/terraform-intel-aws-vm/tree/main/examples/gen-ai-gaudi-demo)
+
+
+### Option 2 - Running Ansible manually via the Operating System command line
+
+By using [ansible-pull](https://docs.ansible.com/ansible/latest/cli/ansible-pull.html), Ansible can run directly on the host.
+
+For example, on Ubuntu:
+
+```bash
+# Install Git 
+sudo apt install git -y
+
+# Install Ansible Key
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+sudo apt update
+
+# Install Ansible
+sudo apt install ansible -y
+
+#Run ansible-pull
+sudo ansible-pull -vv -U https://github.com/intel/optimized-cloud-recipes.git recipes/ai-gaudi-ubuntu/recipe.yml
+
+# Logs at 'tail -f 10 /var/ansible-log'
+```
+
+## Running the Demo
+
+1. SSH into newly created VM and run:
+
+```bash
+sudo docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
+```
+
+2. This will launch the pytorch container where the Gaudi demos can be launched.
+
+## Links
+
+[Intel® Gaudi® AI Accelerator](https://www.intel.com/content/www/us/en/products/details/processors/ai-accelerators/gaudi-overview.html)
+
+[Intel® Gaudi® AI Accelerator - Developer Website](https://developer.habana.ai/)

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -1,0 +1,101 @@
+##########################################################
+# Host configuration                                     #
+##########################################################
+---
+- name: Install pre-requisite packages
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Install pre-requisite packages
+      ansible.builtin.apt:
+        pkg:
+          - python3
+          - python3-pip
+          - python-is-python3
+          - net-tools
+          - libmkl-dev
+        state: present
+        update_cache: true
+    - name: Install Jupyterlab using pip 
+      ansible.builtin.pip:
+        name: jupyterlab
+        state: present
+
+#############################################################################################################################################
+# Setup Gaudi Frameworks                                                                                                                    #
+#                                                                                                                                           #
+# Following the instructions here: https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#sw-stack-installation-bare  #
+#                                                                                                                                           #
+# Run the Habana setup script                                                                                                               #
+# - /tmp/habanalabs-installer.sh install -t base -y                                                                                         #
+# - /tmp/habanalabs-installer.sh install -t dependencies -y                                                                                 #
+# - /tmp/habanalabs-installer.sh install -t pytorch -y                                                                                      #
+#############################################################################################################################################
+- name: Install Habana base
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Download Habana installer
+      ansible.builtin.get_url:
+        url: https://vault.habana.ai/artifactory/gaudi-installer/1.15.1/habanalabs-installer.sh
+        dest: /tmp/habanalabs-installer.sh
+        mode: '0755'
+    - name: Install Habana base
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
+- name: Install Habana dependencies
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Install Habana dependencies using script
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
+      become_user: ubuntu
+      become: true
+- name: Install Habana pytorch
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Install Habana pytorch
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
+
+# Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
+- name: Install Habana Container Runtime
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Download Habana artifactory key
+      ansible.builtin.get_url:
+        url: https://vault.habana.ai/artifactory/api/gpg/key/public
+        dest: /tmp/habana-artifactory-key
+    - name: Add Habana artifactory repository to sources list
+      ansible.builtin.copy:
+        content: |
+          deb https://vault.habana.ai/artifactory/debian jammy main
+        dest: /etc/apt/sources.list.d/artifactory.list
+    - name: Add Habana artifactory key
+      ansible.builtin.shell: apt-key add /tmp/habana-artifactory-key
+    - name: Install Habana Container Runtime
+      ansible.builtin.apt:
+        name: habanalabs-container-runtime
+        state: present
+        update_cache: true
+    - name: Add Habana Container Runtime to the docker daemon.json
+      ansible.builtin.copy:
+        content: |
+          {
+           "runtimes": {
+             "habana": {
+                "path": "/usr/bin/habana-container-runtime",
+                "runtimeArgs": []
+              }
+            }
+          }
+        dest: /etc/docker/daemon.json
+
+# Install the Gaudi pytorch container from Habana Labs 
+- name: Install Gaudi pytorch container
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Pull the Gaudi pytorch container
+      ansible.builtin.shell: docker pull hdocker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
+      

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -110,7 +110,7 @@
   tasks:
     - name: Remove the cron job
       ansible.builtin.shell: crontab -r
-      become_user: ubuntu
+      become_user: root
       become: true
 
     # - name: Remove crontab entry

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -90,6 +90,10 @@
             }
           }
         dest: /etc/docker/daemon.json
+    - name: Restart docker service
+      ansible.builtin.service:
+        name: docker
+        state: restarted
 
 # Install the Gaudi pytorch container from Habana Labs 
 - name: Install Gaudi pytorch container
@@ -99,25 +103,13 @@
     - name: Pull the Gaudi pytorch container
       ansible.builtin.shell: docker pull hdocker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
 
-# Restart the docker service
-- name: Restart docker service
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Restart docker service
-      ansible.builtin.service:
-        name: docker
-        state: restarted
-
 # Remove the crontab entry used to run the ansible playbook after reboot
 - name: Remove crontab entry
   hosts: localhost
   connection: local
   tasks:
     - name: Remove the cron job
-      ansible.builtin.cron:
-        name: "@reboot ansible-playbook /opt/optimized-cloud-recipes/recipes/ai-gaudi-ubuntu/recipe.yml"
-        state: absent
+      ansible.builtin.shell: crontab -r
 
     # - name: Remove crontab entry
     #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -110,3 +110,5 @@
   tasks:
     - name: Remove the cron job
       ansible.builtin.shell: sudo crontab -r
+      become_user: ubuntu
+      become: true

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -111,3 +111,13 @@
 
     # - name: Remove crontab entry
     #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -
+
+# Restart the docker service
+- name: Restart docker service
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Restart docker service
+      ansible.builtin.service:
+        name: docker
+        state: restarted

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -99,6 +99,16 @@
     - name: Pull the Gaudi pytorch container
       ansible.builtin.shell: docker pull hdocker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
 
+# Restart the docker service
+- name: Restart docker service
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Restart docker service
+      ansible.builtin.service:
+        name: docker
+        state: restarted
+
 # Remove the crontab entry used to run the ansible playbook after reboot
 - name: Remove crontab entry
   hosts: localhost
@@ -112,12 +122,3 @@
     # - name: Remove crontab entry
     #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -
 
-# Restart the docker service
-- name: Restart docker service
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Restart docker service
-      ansible.builtin.service:
-        name: docker
-        state: restarted

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -20,51 +20,33 @@
       ansible.builtin.pip:
         name: jupyterlab
         state: present
-# Remove the crontab entry used to run the ansible playbook after reboot
-    - name: Remove crontab entry
-      hosts: localhost
-      connection: local
-      tasks:
-        - name: Remove the cron job
-          ansible.builtin.shell: crontab -u root -r
-#############################################################################################################################################
-# Setup Habana Software Stack                                                                                                                    #
-#                                                                                                                                           #
-# Following the instructions here: https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#sw-stack-installation-bare  #
-#                                                                                                                                           #
-# Run the Habana setup script                                                                                                               #
-# - /tmp/habanalabs-installer.sh install -t base -y                                                                                         #
-# - /tmp/habanalabs-installer.sh install -t dependencies -y                                                                                 #
-# - /tmp/habanalabs-installer.sh install -t pytorch -y                                                                                      #
-#############################################################################################################################################
-- name: Install Habana Software Stack
-  hosts: localhost
-  connection: local
-  tasks:
+    # Remove the crontab entry used to run the ansible playbook after reboot, skip this if not using cloud-init
+    - name: Remove the cron job
+      ansible.builtin.shell: crontab -u root -r
+    #############################################################################################################################################
+    # Setup Habana Software Stack                                                                                                                    #
+    #                                                                                                                                           #
+    # Following the instructions here: https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#sw-stack-installation-bare  #
+    #                                                                                                                                           #
+    # Run the Habana setup script                                                                                                               #
+    # - /tmp/habanalabs-installer.sh install -t base -y                                                                                         #
+    # - /tmp/habanalabs-installer.sh install -t dependencies -y                                                                                 #
+    # - /tmp/habanalabs-installer.sh install -t pytorch -y                                                                                      #
+    #############################################################################################################################################
+    - name: Download Habana installer
+      ansible.builtin.get_url:
+        url: https://vault.habana.ai/artifactory/gaudi-installer/1.15.1/habanalabs-installer.sh
+        dest: /tmp/habanalabs-installer.sh
+        mode: '0755'
     - name: Install Habana base
-      tasks:
-        - name: Download Habana installer
-          ansible.builtin.get_url:
-            url: https://vault.habana.ai/artifactory/gaudi-installer/1.15.1/habanalabs-installer.sh
-            dest: /tmp/habanalabs-installer.sh
-            mode: '0755'
-        - name: Install Habana base
-          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
-    - name: Install Habana dependencies
-      tasks:
-        - name: Install Habana dependencies using script
-          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
-          become_user: ubuntu
-          become: true
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
+    - name: Install Habana dependencies using script
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
+      become_user: ubuntu
+      become: true
     - name: Install Habana pytorch
-      tasks:
-        - name: Install Habana pytorch
-          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
-# Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
-- name: Install Habana Container Runtime
-  hosts: localhost
-  connection: local
-  tasks:
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
+    # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
     - name: Download Habana artifactory key
       ansible.builtin.get_url:
         url: https://vault.habana.ai/artifactory/api/gpg/key/public
@@ -97,10 +79,6 @@
       ansible.builtin.service:
         name: docker
         state: restarted
-# Install the Gaudi pytorch container from Habana Labs 
-- name: Install Gaudi pytorch container
-  hosts: localhost
-  connection: local
-  tasks:
+    # Install the Gaudi pytorch container from Habana Labs 
     - name: Pull the Gaudi pytorch container
       ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -110,6 +110,8 @@
   tasks:
     - name: Remove the cron job
       ansible.builtin.shell: crontab -r
+      become_user: ubuntu
+      become: true
 
     # - name: Remove crontab entry
     #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -2,7 +2,7 @@
 # Host configuration                                     #
 ##########################################################
 ---
-- name: Install pre-requisite packages
+- name: Handle pre-requisites
   hosts: localhost
   connection: local
   tasks:
@@ -20,9 +20,15 @@
       ansible.builtin.pip:
         name: jupyterlab
         state: present
-
+# Remove the crontab entry used to run the ansible playbook after reboot
+    - name: Remove crontab entry
+      hosts: localhost
+      connection: local
+      tasks:
+        - name: Remove the cron job
+          ansible.builtin.shell: crontab -u root -r
 #############################################################################################################################################
-# Setup Gaudi Frameworks                                                                                                                    #
+# Setup Habana Software Stack                                                                                                                    #
 #                                                                                                                                           #
 # Following the instructions here: https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#sw-stack-installation-bare  #
 #                                                                                                                                           #
@@ -31,32 +37,29 @@
 # - /tmp/habanalabs-installer.sh install -t dependencies -y                                                                                 #
 # - /tmp/habanalabs-installer.sh install -t pytorch -y                                                                                      #
 #############################################################################################################################################
-- name: Install Habana base
+- name: Install Habana Software Stack
   hosts: localhost
   connection: local
   tasks:
-    - name: Download Habana installer
-      ansible.builtin.get_url:
-        url: https://vault.habana.ai/artifactory/gaudi-installer/1.15.1/habanalabs-installer.sh
-        dest: /tmp/habanalabs-installer.sh
-        mode: '0755'
     - name: Install Habana base
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
-- name: Install Habana dependencies
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Install Habana dependencies using script
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
-      become_user: ubuntu
-      become: true
-- name: Install Habana pytorch
-  hosts: localhost
-  connection: local
-  tasks:
+      tasks:
+        - name: Download Habana installer
+          ansible.builtin.get_url:
+            url: https://vault.habana.ai/artifactory/gaudi-installer/1.15.1/habanalabs-installer.sh
+            dest: /tmp/habanalabs-installer.sh
+            mode: '0755'
+        - name: Install Habana base
+          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
+    - name: Install Habana dependencies
+      tasks:
+        - name: Install Habana dependencies using script
+          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
+          become_user: ubuntu
+          become: true
     - name: Install Habana pytorch
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
-
+      tasks:
+        - name: Install Habana pytorch
+          ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
 # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
 - name: Install Habana Container Runtime
   hosts: localhost
@@ -94,19 +97,10 @@
       ansible.builtin.service:
         name: docker
         state: restarted
-
 # Install the Gaudi pytorch container from Habana Labs 
 - name: Install Gaudi pytorch container
   hosts: localhost
   connection: local
   tasks:
     - name: Pull the Gaudi pytorch container
-      ansible.builtin.shell: docker pull hdocker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
-
-# Remove the crontab entry used to run the ansible playbook after reboot
-- name: Remove crontab entry
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Remove the cron job
-      ansible.builtin.shell: crontab -u root -r
+      ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -109,10 +109,4 @@
   connection: local
   tasks:
     - name: Remove the cron job
-      ansible.builtin.shell: crontab -r
-      become_user: root
-      become: true
-
-    # - name: Remove crontab entry
-    #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -
-
+      ansible.builtin.shell: sudo crontab -r

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -104,5 +104,10 @@
   hosts: localhost
   connection: local
   tasks:
-    - name: Remove crontab entry
-      ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -
+    - name: Remove the cron job
+      ansible.builtin.cron:
+        name: "@reboot ansible-playbook /opt/optimized-cloud-recipes/recipes/ai-gaudi-ubuntu/recipe.yml"
+        state: absent
+
+    # - name: Remove crontab entry
+    #   ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -2,16 +2,6 @@
 # Host configuration                                     #
 ##########################################################
 ---
-# Restart the host after cloud-init updates the packages
-- name: Restart the host
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: Restart the host
-      ansible.builtin.reboot:
-        reboot_timeout: 300
-        reboot_timeout: 300
-        test_command: whoami
 - name: Install pre-requisite packages
   hosts: localhost
   connection: local

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -98,4 +98,11 @@
   tasks:
     - name: Pull the Gaudi pytorch container
       ansible.builtin.shell: docker pull hdocker pull vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
-      
+
+# Remove the crontab entry used to run the ansible playbook after reboot
+- name: Remove crontab entry
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Remove crontab entry
+      ansible.builtin.shell: crontab -l | grep -v 'ai-gaudi-ubuntu' | crontab -

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -2,6 +2,16 @@
 # Host configuration                                     #
 ##########################################################
 ---
+# Restart the host after cloud-init updates the packages
+- name: Restart the host
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Restart the host
+      ansible.builtin.reboot:
+        reboot_timeout: 300
+        reboot_timeout: 300
+        test_command: whoami
 - name: Install pre-requisite packages
   hosts: localhost
   connection: local

--- a/recipes/ai-gaudi-ubuntu/recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/recipe.yml
@@ -109,6 +109,4 @@
   connection: local
   tasks:
     - name: Remove the cron job
-      ansible.builtin.shell: sudo crontab -r
-      become_user: ubuntu
-      become: true
+      ansible.builtin.shell: crontab -u root -r


### PR DESCRIPTION
Create a recipe to install the base Habana Gaudi packages on a plain Ubuntu image. Validated on DL1 instances in AWS.