### PR TITLE
Add stand alone Gaudi recipe and move to Habana 1.16.0 stack

### DIFF
--- a/recipes/ai-gaudi-ubuntu/README.md
+++ b/recipes/ai-gaudi-ubuntu/README.md
@@ -48,7 +48,7 @@ sudo apt update
 sudo apt install ansible -y
 
 #Run ansible-pull
-sudo ansible-pull -vv -U https://github.com/intel/optimized-cloud-recipes.git recipes/ai-gaudi-ubuntu/recipe.yml
+sudo ansible-pull -vv -U https://github.com/intel/optimized-cloud-recipes.git recipes/ai-gaudi-ubuntu/standalone-recipe.yml
 
 # Logs at 'tail -f 10 /var/log/syslog'
 ```
@@ -58,7 +58,7 @@ sudo ansible-pull -vv -U https://github.com/intel/optimized-cloud-recipes.git re
 1. SSH into newly created VM and run:
 
 ```bash
-sudo docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
+sudo docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
 ```
 
 2. This will launch the pytorch container where the Gaudi demos can be launched.

--- a/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
@@ -6,21 +6,21 @@
   hosts: localhost
   connection: local
   tasks:
-    # - name: Install pre-requisite packages
-    #   ansible.builtin.apt:
-    #     pkg:
-    #       - python3
-    #       - python3-pip
-    #       - python-is-python3
-    #       - net-tools
-    #       - libmkl-dev
-    #       - docker.io
-    #     state: present
-    #     update_cache: true
-    # - name: Install Jupyterlab using pip 
-    #   ansible.builtin.pip:
-    #     name: jupyterlab
-    #     state: present
+    - name: Install pre-requisite packages
+      ansible.builtin.apt:
+        pkg:
+          - python3
+          - python3-pip
+          - python-is-python3
+          - net-tools
+          - libmkl-dev
+          - docker.io
+        state: present
+        update_cache: true
+    - name: Install Jupyterlab using pip 
+      ansible.builtin.pip:
+        name: jupyterlab
+        state: present
     #############################################################################################################################################
     # Setup Habana Software Stack                                                                                                                    #
     #                                                                                                                                           #
@@ -48,52 +48,47 @@
         regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
         line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
         backrefs: yes
-    # - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt update
-    #   ansible.builtin.lineinfile:
-    #     path: /tmp/habanalabs-installer.sh
-    #     regexp: ^\\${_SUDO_CMD} DEBIAN_FRONTEND=noninteractive \\${__pkg__} update
-    #     line: \\${_SUDO_CMD} \\${__pkg__} update
-    # - name: Install Habana base
-    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
-    # - name: Install Habana dependencies using script
-    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
-    #   become_user: ubuntu
-    #   become: true
-    # - name: Install Habana pytorch
-    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
-    # # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
-    # - name: Download Habana artifactory key
-    #   ansible.builtin.get_url:
-    #     url: https://vault.habana.ai/artifactory/api/gpg/key/public
-    #     dest: /tmp/habana-artifactory-key
-    # - name: Add Habana artifactory repository to sources list
-    #   ansible.builtin.copy:
-    #     content: |
-    #       deb https://vault.habana.ai/artifactory/debian jammy main
-    #     dest: /etc/apt/sources.list.d/artifactory.list
-    # - name: Add Habana artifactory key
-    #   ansible.builtin.shell: apt-key add /tmp/habana-artifactory-key
-    # - name: Install Habana Container Runtime
-    #   ansible.builtin.apt:
-    #     name: habanalabs-container-runtime
-    #     state: present
-    #     update_cache: true
-    # - name: Add Habana Container Runtime to the docker daemon.json
-    #   ansible.builtin.copy:
-    #     content: |
-    #       {
-    #        "runtimes": {
-    #          "habana": {
-    #             "path": "/usr/bin/habana-container-runtime",
-    #             "runtimeArgs": []
-    #           }
-    #         }
-    #       }
-    #     dest: /etc/docker/daemon.json
-    # - name: Restart docker service
-    #   ansible.builtin.service:
-    #     name: docker
-    #     state: restarted
-    # # Install the Gaudi pytorch container from Habana Labs 
-    # - name: Pull the Gaudi pytorch container
-    #   ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
+    - name: Install Habana base
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
+    - name: Install Habana dependencies using script
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
+      become_user: ubuntu
+      become: true
+    - name: Install Habana pytorch
+      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
+    # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
+    - name: Download Habana artifactory key
+      ansible.builtin.get_url:
+        url: https://vault.habana.ai/artifactory/api/gpg/key/public
+        dest: /tmp/habana-artifactory-key
+    - name: Add Habana artifactory repository to sources list
+      ansible.builtin.copy:
+        content: |
+          deb https://vault.habana.ai/artifactory/debian jammy main
+        dest: /etc/apt/sources.list.d/artifactory.list
+    - name: Add Habana artifactory key
+      ansible.builtin.shell: apt-key add /tmp/habana-artifactory-key
+    - name: Install Habana Container Runtime
+      ansible.builtin.apt:
+        name: habanalabs-container-runtime
+        state: present
+        update_cache: true
+    - name: Add Habana Container Runtime to the docker daemon.json
+      ansible.builtin.copy:
+        content: |
+          {
+           "runtimes": {
+             "habana": {
+                "path": "/usr/bin/habana-container-runtime",
+                "runtimeArgs": []
+              }
+            }
+          }
+        dest: /etc/docker/daemon.json
+    - name: Restart docker service
+      ansible.builtin.service:
+        name: docker
+        state: restarted
+    # Install the Gaudi pytorch container from Habana Labs 
+    - name: Pull the Gaudi pytorch container
+      ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest

--- a/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
@@ -14,15 +14,13 @@
           - python-is-python3
           - net-tools
           - libmkl-dev
+          - docker.io
         state: present
         update_cache: true
     - name: Install Jupyterlab using pip 
       ansible.builtin.pip:
         name: jupyterlab
         state: present
-    # Remove the crontab entry used to run the ansible playbook after reboot, skip this if not using cloud-init
-    - name: Remove the cron job
-      ansible.builtin.shell: crontab -u root -r
     #############################################################################################################################################
     # Setup Habana Software Stack                                                                                                                    #
     #                                                                                                                                           #

--- a/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
+++ b/recipes/ai-gaudi-ubuntu/standalone-recipe.yml
@@ -6,21 +6,21 @@
   hosts: localhost
   connection: local
   tasks:
-    - name: Install pre-requisite packages
-      ansible.builtin.apt:
-        pkg:
-          - python3
-          - python3-pip
-          - python-is-python3
-          - net-tools
-          - libmkl-dev
-          - docker.io
-        state: present
-        update_cache: true
-    - name: Install Jupyterlab using pip 
-      ansible.builtin.pip:
-        name: jupyterlab
-        state: present
+    # - name: Install pre-requisite packages
+    #   ansible.builtin.apt:
+    #     pkg:
+    #       - python3
+    #       - python3-pip
+    #       - python-is-python3
+    #       - net-tools
+    #       - libmkl-dev
+    #       - docker.io
+    #     state: present
+    #     update_cache: true
+    # - name: Install Jupyterlab using pip 
+    #   ansible.builtin.pip:
+    #     name: jupyterlab
+    #     state: present
     #############################################################################################################################################
     # Setup Habana Software Stack                                                                                                                    #
     #                                                                                                                                           #
@@ -36,47 +36,64 @@
         url: https://vault.habana.ai/artifactory/gaudi-installer/1.16.0/habanalabs-installer.sh
         dest: /tmp/habanalabs-installer.sh
         mode: '0755'
-    - name: Install Habana base
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
-    - name: Install Habana dependencies using script
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
-      become_user: ubuntu
-      become: true
-    - name: Install Habana pytorch
-      ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
-    # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
-    - name: Download Habana artifactory key
-      ansible.builtin.get_url:
-        url: https://vault.habana.ai/artifactory/api/gpg/key/public
-        dest: /tmp/habana-artifactory-key
-    - name: Add Habana artifactory repository to sources list
-      ansible.builtin.copy:
-        content: |
-          deb https://vault.habana.ai/artifactory/debian jammy main
-        dest: /etc/apt/sources.list.d/artifactory.list
-    - name: Add Habana artifactory key
-      ansible.builtin.shell: apt-key add /tmp/habana-artifactory-key
-    - name: Install Habana Container Runtime
-      ansible.builtin.apt:
-        name: habanalabs-container-runtime
-        state: present
-        update_cache: true
-    - name: Add Habana Container Runtime to the docker daemon.json
-      ansible.builtin.copy:
-        content: |
-          {
-           "runtimes": {
-             "habana": {
-                "path": "/usr/bin/habana-container-runtime",
-                "runtimeArgs": []
-              }
-            }
-          }
-        dest: /etc/docker/daemon.json
-    - name: Restart docker service
-      ansible.builtin.service:
-        name: docker
-        state: restarted
-    # Install the Gaudi pytorch container from Habana Labs 
-    - name: Pull the Gaudi pytorch container
-      ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
+    - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
+      ansible.builtin.lineinfile:
+        path: /tmp/habanalabs-installer.sh
+        regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
+        line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
+        backrefs: yes
+    - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
+      ansible.builtin.lineinfile:
+        path: /tmp/habanalabs-installer.sh
+        regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
+        line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
+        backrefs: yes
+    # - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt update
+    #   ansible.builtin.lineinfile:
+    #     path: /tmp/habanalabs-installer.sh
+    #     regexp: ^\\${_SUDO_CMD} DEBIAN_FRONTEND=noninteractive \\${__pkg__} update
+    #     line: \\${_SUDO_CMD} \\${__pkg__} update
+    # - name: Install Habana base
+    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t base -y
+    # - name: Install Habana dependencies using script
+    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t dependencies -y
+    #   become_user: ubuntu
+    #   become: true
+    # - name: Install Habana pytorch
+    #   ansible.builtin.shell: /tmp/habanalabs-installer.sh install -t pytorch --venv -y
+    # # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
+    # - name: Download Habana artifactory key
+    #   ansible.builtin.get_url:
+    #     url: https://vault.habana.ai/artifactory/api/gpg/key/public
+    #     dest: /tmp/habana-artifactory-key
+    # - name: Add Habana artifactory repository to sources list
+    #   ansible.builtin.copy:
+    #     content: |
+    #       deb https://vault.habana.ai/artifactory/debian jammy main
+    #     dest: /etc/apt/sources.list.d/artifactory.list
+    # - name: Add Habana artifactory key
+    #   ansible.builtin.shell: apt-key add /tmp/habana-artifactory-key
+    # - name: Install Habana Container Runtime
+    #   ansible.builtin.apt:
+    #     name: habanalabs-container-runtime
+    #     state: present
+    #     update_cache: true
+    # - name: Add Habana Container Runtime to the docker daemon.json
+    #   ansible.builtin.copy:
+    #     content: |
+    #       {
+    #        "runtimes": {
+    #          "habana": {
+    #             "path": "/usr/bin/habana-container-runtime",
+    #             "runtimeArgs": []
+    #           }
+    #         }
+    #       }
+    #     dest: /etc/docker/daemon.json
+    # - name: Restart docker service
+    #   ansible.builtin.service:
+    #     name: docker
+    #     state: restarted
+    # # Install the Gaudi pytorch container from Habana Labs 
+    # - name: Pull the Gaudi pytorch container
+    #   ansible.builtin.shell: docker pull vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest


### PR DESCRIPTION
Updated the readme to reflect running the stand alone recipe as there are problems with running the normal recipe outside of the Terraform flow.
Updated the version of the Habana stack being used to 1.16.0.