### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+UBUNTU_CODENAME=jammy
+wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
 sudo apt update
 
 # Install Ansible

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The primary goal of Intel Cloud Optimized Modules for Ansible is to simplify and
 
 Some examples of technologies that can be enabled and optimized are:
 
-- OPEA - Open Platform for AI[LINK](https://opea.dev/)
+- OPEA - [Open Platform for Enterprise AI](https://opea.dev/)
 - RAG - Retrieval Augmented Generation
-- Intel Guadi AI Accelerator
+- Intel Gaudi AI Accelerator
 - OneAPI AI Training and Inference with Intel® Advanced Matrix Extensions (Intel® AMX)
 - Intel AMX - Advanced Matrix Extensions
 - Intel SGX - Software Guard Extensions

--- a/README.md
+++ b/README.md
@@ -126,11 +126,9 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 # Install Git 
 sudo apt install git -y
 
-# Install Ansible Key
-UBUNTU_CODENAME=jammy
-wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
-sudo apt update
+# Install Ansible Key (Ubuntu), see ansible installation guide above for other distros.
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 sudo apt install git -y
 
 # Install Ansible Key (Ubuntu), see ansible installation guide above for other distros.
+sudo apt update
 sudo apt install software-properties-common
 sudo add-apt-repository --yes --update ppa:ansible/ansible
 


### PR DESCRIPTION
* Fix small typos

* Update the README.md to be consistent with ansible documentation. i.e. there was deprecation of using apt-key see: https://docs.ansible.com/ansible/latest/installation_guide/installation_distros.html. Partially addresses  issue #53, (will need to update recipe specific README.md later).
