### PR TITLE
Bare Metal Recipe for Gaudi 1.18.0 on Ubuntu

### DIFF
--- a/recipes/ai-gaudi-ubuntu/README.md
+++ b/recipes/ai-gaudi-ubuntu/README.md
@@ -37,6 +37,7 @@ Pick the recipe file based on the version of the Intel® Gaudi® drivers
 | 1.16.0         | [recipe.yml](recipe.yml)| Used in specific demos, works on AWS DL1 instances |
 | 1.16.2         | [standalone-recipe-1.16.2.yml](standalone-recipe-1.16.2.yml)| Doesn't upgrade SPI Firmware |
 | 1.17.1         | [baremetal-recipe-1.17.1.yml](baremetal-recipe-1.17.1.yml)| For clean installs or upgrades. Upgrades SPI Firmware.|
+| 1.18.0         | [baremetal-recipe-1.18.0.yml](baremetal-recipe-1.18.0.yml)| For clean installs or upgrades. Checks to see if the SPI Firmware needs to be upgraded. |
 
 For example, on Ubuntu:
 
@@ -55,7 +56,7 @@ sudo apt install ansible -y
 git clone https://github.com/intel/optimized-cloud-recipes.git 
 
 # Run the recipe, pick the recipe version for the Habana version you want
-sudo ansible-playbook optimized-cloud-recipes/recipes/ai-gaudi-ubuntu/baremetal-1.17.1.yml
+sudo ansible-playbook optimized-cloud-recipes/recipes/ai-gaudi-ubuntu/baremetal-1.18.0.yml
 
 # Logs at 'tail -f 10 /var/log/syslog'
 ```
@@ -65,7 +66,7 @@ sudo ansible-playbook optimized-cloud-recipes/recipes/ai-gaudi-ubuntu/baremetal-
 1. SSH into newly created VM and run:
 
 ```bash
-sudo docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
+sudo docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0:latest
 ```
 
 2. This will launch the pytorch container where the Gaudi demos can be launched.

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -1,12 +1,14 @@
 ##########################################################
 # Host configuration                                     #
 # Installs version: 1.18.1                               #
-# Installs SPI FW: 1.18.0-fw-53.1.1-sec-8                #
+# Installs SPI FW: 1.18.0-fw-53.1.1-sec-9                #
+#                                                        #
 ##########################################################
 ---
 - name: Handle pre-requisites
   hosts: localhost
   vars:
+    # These are the packages that will be checked. If any are missing, then it will install as if it's a clean install. If they are upgradable, then the upgrade will run instead.
     habana_packages:
       - habanalabs-container-runtime
       - habanalabs-dkms
@@ -15,7 +17,6 @@
       - habanalabs-firmware
       - habanalabs-graph
       - habanalabs-qual
-      - habanalabs-qual-workloads
       - habanalabs-rdma-core
       - habanalabs-thunk
     habana_drivers:
@@ -25,7 +26,7 @@
       - habanalabs
     habana_version: "1.18.0"  
     habana_installer: "/opt/habanalabs-installer-{{ habana_version }}.sh"
-    habana_spi_fw_version: "1.18.0-fw-53.1.1-sec-8"
+    habana_spi_fw_version: "1.18.0-fw-53.1.1-sec-9"
   tasks:
     - name: Install pre-requisite packages
       ansible.builtin.apt:
@@ -39,7 +40,7 @@
           - ethtool
         state: present
         update_cache: true
-    - name: Install Jupyterlab using pip 
+    - name: Install Jupyterlab using pip
       ansible.builtin.pip:
         name: jupyterlab
         state: present
@@ -76,7 +77,7 @@
     ##########################################################
 
     - name: Check if Habana packages are installed
-      command: dpkg-query -W -f='${Status}' {{ item }}
+      shell: dpkg-query -W -f='${Status}\n' {{ item }} | grep -q '^install ok installed$'
       register: package_status
       failed_when: false
       changed_when: false
@@ -92,17 +93,9 @@
       set_fact:
         missing_packages: "{{ package_status.results | selectattr('rc', 'ne', 0) | map(attribute='item') | list }}"
         upgradable_packages: "{{ upgrade_status.results | selectattr('stdout', 'search', 'upgradable') | map(attribute='item') | list }}"
-  
 
-    
-    # # Unload the drivers before proceeding
-    # - name: Unload the Habana drivers in specified order
-    #   modprobe:
-    #     name: "{{ item }}"
-    #     state: absent
-    #   loop: "{{ habana_drivers | reverse | list }}"  
 
-    # Install packages if any are missing or it's a clean install
+    #Install packages if any are missing or it's a clean install
 
     - name: Tasks if packages are missing
       block:
@@ -156,15 +149,26 @@
           register: install_result
       when: missing_packages | length > 0
 
-
-
     # Update Habana Stack if already installed
     - name: Update packages if any are not up to date
-      shell: "{{ habana_installer }} upgrade -t all"
-      when: upgradable_packages | length > 0
-      register: update_result
-
-    ## Will do the firmware update each time.
+      block:
+        - name: Unload the Habana drivers in specified order
+          modprobe:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ habana_drivers | reverse | list }}"
+        - name: Run the upgrade
+          shell: "{{ habana_installer }} upgrade -t all"
+          register: update_result
+        - name: Update the Habana container Runtime
+          apt:
+            name: habanalabs-container-runtime
+            state: latest
+            update_cache: no
+      when: 
+        - upgradable_packages | length > 0
+        - missing_packages | length == 0
+  
     ## Future versions: Need to add check here to see if firmware needs to be updated
     ## Will unload the drivers, update the SPI firmware and then reload the drivers
 

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -146,13 +146,13 @@
     - name: Tasks if packages are missing
       block:
         - name: Install Habana base
-          shell: {{ habana_installer }} install -t base -y
+          shell: "{{ habana_installer }} install -t base -y"
           register: install_result
         - name: Install Habana dependencies using script
-          shell: {{ habana_installer }} install -t dependencies -y
+          shell: "{{ habana_installer }} install -t dependencies -y"
           register: install_result
         - name: Install Habana pytorch
-          shell: {{ habana_installer }} install -t pytorch -y
+          shell: "{{ habana_installer }} install -t pytorch -y"
           register: install_result
         # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
         - name: Download Habana artifactory key
@@ -199,7 +199,7 @@
 
     # Update Habana Stack if already installed
     - name: Update packages if any are not up to date
-      shell: {{ habana_installer }} upgrade -t all
+      shell: "{{ habana_installer }} upgrade -t all"
       when: upgradable_packages | length > 0
       register: update_result
 

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -210,7 +210,7 @@
           - "  - Version match check: {{ firmware_versions[0] == habana_spi_fw_version }}"
 
     - name: SPI Firmware Update
-      when: not all_versions_match
+      when: not all_fw_versions_match
       block:
         - name: Unload the Habana drivers in specified order
           modprobe:

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -194,7 +194,7 @@
     - name: Display firmware check results
       debug:
         msg: >
-          {% if all_versions_match %}
+          {% if all_fw_versions_match %}
           All firmware versions match expected version {{ habana_spi_fw_version }}. No action needed.
           {% else %}
           Firmware version mismatch detected. Will proceed with driver operations.

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -93,46 +93,7 @@
         missing_packages: "{{ package_status.results | selectattr('rc', 'ne', 0) | map(attribute='item') | list }}"
         upgradable_packages: "{{ upgrade_status.results | selectattr('stdout', 'search', 'upgradable') | map(attribute='item') | list }}"
   
-    # Check if the SPI firmware is up to date
-    - name: Check firmware version
-      shell: "hl-smi -L | grep SPI"
-      register: firmware_check
-      changed_when: false
-    - name: Display raw firmware check output
-      debug:
-        var: firmware_check.stdout_lines
 
-    - name: Analyze firmware versions
-      set_fact:
-        firmware_versions: "{{ firmware_check.stdout_lines | map('regex_search', '([0-9]+\\.[0-9]+\\.[0-9]+-fw-[0-9]+\\.[0-9]+\\.[0-9]+-sec-[0-9]+)') | select('string') | list }}"
-    - name: Display extracted firmware versions
-      debug:
-        msg:
-          - "Extracted versions: {{ firmware_versions | default([]) }}"
-          - "Expected version: {{ habana_spi_fw_version }}"
-          - "Number of versions found: {{ firmware_versions | default([]) | length }}"
-
-    - name: Check if all firmware versions match
-      set_fact:
-        all_fw_versions_match: "{{ true if (firmware_versions | unique | list | length == 1) and (firmware_versions[0] == habana_spi_fw_version) else false }}"
-
-    - name: Display firmware check results
-      debug:
-        msg: >
-          {% if all_versions_match %}
-          All firmware versions match expected version {{ habana_spi_fw_version }}. No action needed.
-          {% else %}
-          Firmware version mismatch detected. Will proceed with driver operations.
-          Found versions: {{ firmware_versions | join(', ') }}
-          {% endif %}
-
-    - name: Display match status
-      debug:
-        msg:
-          - "All versions match: {{ all_fw_versions_match }}"
-          - "Condition details:"
-          - "  - Unique versions check: {{ firmware_versions | unique | list | length == 1 }}"
-          - "  - Version match check: {{ firmware_versions[0] == habana_spi_fw_version }}"
     
     # # Unload the drivers before proceeding
     # - name: Unload the Habana drivers in specified order
@@ -207,8 +168,46 @@
     ## Future versions: Need to add check here to see if firmware needs to be updated
     ## Will unload the drivers, update the SPI firmware and then reload the drivers
 
+    # Check if the SPI firmware is up to date
+    - name: Check firmware version
+      shell: "hl-smi -L | grep SPI"
+      register: firmware_check
+      changed_when: false
+    - name: Display raw firmware check output
+      debug:
+        var: firmware_check.stdout_lines
 
+    - name: Analyze firmware versions
+      set_fact:
+        firmware_versions: "{{ firmware_check.stdout_lines | map('regex_search', '([0-9]+\\.[0-9]+\\.[0-9]+-fw-[0-9]+\\.[0-9]+\\.[0-9]+-sec-[0-9]+)') | select('string') | list }}"
+    - name: Display extracted firmware versions
+      debug:
+        msg:
+          - "Extracted versions: {{ firmware_versions | default([]) }}"
+          - "Expected version: {{ habana_spi_fw_version }}"
+          - "Number of versions found: {{ firmware_versions | default([]) | length }}"
 
+    - name: Check if all firmware versions match
+      set_fact:
+        all_fw_versions_match: "{{ true if (firmware_versions | unique | list | length == 1) and (firmware_versions[0] == habana_spi_fw_version) else false }}"
+
+    - name: Display firmware check results
+      debug:
+        msg: >
+          {% if all_versions_match %}
+          All firmware versions match expected version {{ habana_spi_fw_version }}. No action needed.
+          {% else %}
+          Firmware version mismatch detected. Will proceed with driver operations.
+          Found versions: {{ firmware_versions | join(', ') }}
+          {% endif %}
+
+    - name: Display match status
+      debug:
+        msg:
+          - "All versions match: {{ all_fw_versions_match }}"
+          - "Condition details:"
+          - "  - Unique versions check: {{ firmware_versions | unique | list | length == 1 }}"
+          - "  - Version match check: {{ firmware_versions[0] == habana_spi_fw_version }}"
 
     - name: SPI Firmware Update
       when: not all_versions_match

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -56,17 +56,17 @@
     - name: Download Habana installer
       ansible.builtin.get_url:
         url: https://vault.habana.ai/artifactory/gaudi-installer/{{ habana_version }}/habanalabs-installer.sh
-        dest: {{ habana_installer }}
+        dest: "{{ habana_installer }}"
         mode: '0755'
     - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
       ansible.builtin.lineinfile:
-        path: {{ habana_installer }}
+        path: "{{ habana_installer }}"
         regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
         line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
         backrefs: yes
     - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
       ansible.builtin.lineinfile:
-        path: {{ habana_installer }}
+        path: "{{ habana_installer }}"
         regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
         line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
         backrefs: yes

--- a/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
+++ b/recipes/ai-gaudi-ubuntu/baremetal-recipe-1.18.0.yml
@@ -1,7 +1,7 @@
 ##########################################################
 # Host configuration                                     #
-# Installs version: 1.17.1                               #
-# Installs SPI FW: 1.17.0-fw-51.2.0-sec-9                #
+# Installs version: 1.18.1                               #
+# Installs SPI FW: 1.18.0-fw-53.1.1-sec-8                #
 ##########################################################
 ---
 - name: Handle pre-requisites
@@ -15,6 +15,7 @@
       - habanalabs-firmware
       - habanalabs-graph
       - habanalabs-qual
+      - habanalabs-qual-workloads
       - habanalabs-rdma-core
       - habanalabs-thunk
     habana_drivers:
@@ -22,8 +23,9 @@
       - habanalabs_ib
       - habanalabs_cn
       - habanalabs
-    habana_installer: "/opt/habanalabs-installer-1.17.1.sh"
-    habana_spi_fw_version: "1.17.0-fw-51.2.0-sec-9"
+    habana_version: "1.18.0"  
+    habana_installer: "/opt/habanalabs-installer-{{ habana_version }}.sh"
+    habana_spi_fw_version: "1.18.0-fw-53.1.1-sec-8"
   tasks:
     - name: Install pre-requisite packages
       ansible.builtin.apt:
@@ -34,6 +36,7 @@
           - net-tools
           - libmkl-dev
           - docker.io
+          - ethtool
         state: present
         update_cache: true
     - name: Install Jupyterlab using pip 
@@ -41,7 +44,7 @@
         name: jupyterlab
         state: present
     #############################################################################################################################################
-    # Setup Habana Software Stack                                                                                                                    #
+    # Setup Habana Software Stack                                                                                                               #
     #                                                                                                                                           #
     # Following the instructions here: https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#sw-stack-installation-bare  #
     #                                                                                                                                           #
@@ -52,18 +55,18 @@
     #############################################################################################################################################
     - name: Download Habana installer
       ansible.builtin.get_url:
-        url: https://vault.habana.ai/artifactory/gaudi-installer/1.17.1/habanalabs-installer.sh
-        dest: /opt/habanalabs-installer-1.17.1.sh
+        url: https://vault.habana.ai/artifactory/gaudi-installer/{{ habana_version }}/habanalabs-installer.sh
+        dest: {{ habana_installer }}
         mode: '0755'
     - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
       ansible.builtin.lineinfile:
-        path: /opt/habanalabs-installer-1.17.1.sh
+        path: {{ habana_installer }}
         regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
         line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
         backrefs: yes
     - name: Modify the Habana installer to remove the DEBIAN_FRONTEND=noninteractive flag from apt install libmkl-dev
       ansible.builtin.lineinfile:
-        path: /opt/habanalabs-installer-1.17.1.sh
+        path: {{ habana_installer }}
         regexp: "\\$\\{_SUDO_CMD\\} DEBIAN_FRONTEND=noninteractive \\$\\{__pkg__\\} install -y libmkl-dev"
         line: "             ${_SUDO_CMD} ${__pkg__} install -y libmkl-dev"
         backrefs: yes
@@ -89,80 +92,8 @@
       set_fact:
         missing_packages: "{{ package_status.results | selectattr('rc', 'ne', 0) | map(attribute='item') | list }}"
         upgradable_packages: "{{ upgrade_status.results | selectattr('stdout', 'search', 'upgradable') | map(attribute='item') | list }}"
-
-    # Install packages if any are missing or it's a clean install
-
-    - name: Install Habana base
-      shell: /opt/habanalabs-installer-1.17.1.sh install -t base -y
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Install Habana dependencies using script
-      shell: /opt/habanalabs-installer-1.17.1.sh install -t dependencies -y
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Install Habana pytorch
-      shell: /opt/habanalabs-installer-1.17.1.sh install -t pytorch -y
-      when: missing_packages | length > 0
-      register: install_result
-
-    # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
-    - name: Download Habana artifactory key
-      get_url:
-        url: https://vault.habana.ai/artifactory/api/gpg/key/public
-        dest: /tmp/habana-artifactory-key
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Add Habana artifactory repository to sources list
-      copy:
-        content: |
-          deb https://vault.habana.ai/artifactory/debian jammy main
-        dest: /etc/apt/sources.list.d/artifactory.list
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Add Habana artifactory key
-      shell: apt-key add /tmp/habana-artifactory-key
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Install Habana Container Runtime
-      apt:
-        name: habanalabs-container-runtime
-        state: present
-        update_cache: true
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Add Habana Container Runtime to the docker daemon.json
-      copy:
-        content: |
-          {
-           "runtimes": {
-             "habana": {
-                "path": "/usr/bin/habana-container-runtime",
-                "runtimeArgs": []
-              }
-            }
-          }
-        dest: /etc/docker/daemon.json
-      when: missing_packages | length > 0
-      register: install_result
-    - name: Restart docker service
-      service:
-        name: docker
-        state: restarted
-      when: missing_packages | length > 0
-      register: install_result
-
-    # Update Habana Stack if already installed
-    - name: Update packages if any are not up to date
-      shell: /opt/habanalabs-installer-1.17.1.sh upgrade -t all
-      when: upgradable_packages | length > 0
-      register: update_result
-
-    ## Due to versioning of the firmware and drivers in 1.17.1, won't be able to reliably check to see if the firmware update is needed.
-    ## Will do the firmware update each time.
-    ## Future versions: Need to add check here to see if firmware needs to be updated
-    ## Will unload the drivers, update the SPI firmware and then reload the drivers
-
-
+  
+    # Check if the SPI firmware is up to date
     - name: Check firmware version
       shell: "hl-smi -L | grep SPI"
       register: firmware_check
@@ -183,7 +114,7 @@
 
     - name: Check if all firmware versions match
       set_fact:
-        all_versions_match: "{{ true if (firmware_versions | unique | list | length == 1) and (firmware_versions[0] == habana_spi_fw_version) else false }}"
+        all_fw_versions_match: "{{ true if (firmware_versions | unique | list | length == 1) and (firmware_versions[0] == habana_spi_fw_version) else false }}"
 
     - name: Display firmware check results
       debug:
@@ -198,10 +129,85 @@
     - name: Display match status
       debug:
         msg:
-          - "All versions match: {{ all_versions_match }}"
+          - "All versions match: {{ all_fw_versions_match }}"
           - "Condition details:"
           - "  - Unique versions check: {{ firmware_versions | unique | list | length == 1 }}"
           - "  - Version match check: {{ firmware_versions[0] == habana_spi_fw_version }}"
+    
+    # # Unload the drivers before proceeding
+    # - name: Unload the Habana drivers in specified order
+    #   modprobe:
+    #     name: "{{ item }}"
+    #     state: absent
+    #   loop: "{{ habana_drivers | reverse | list }}"  
+
+    # Install packages if any are missing or it's a clean install
+
+    - name: Tasks if packages are missing
+      block:
+        - name: Install Habana base
+          shell: {{ habana_installer }} install -t base -y
+          register: install_result
+        - name: Install Habana dependencies using script
+          shell: {{ habana_installer }} install -t dependencies -y
+          register: install_result
+        - name: Install Habana pytorch
+          shell: {{ habana_installer }} install -t pytorch -y
+          register: install_result
+        # Install the Habana Container Runtime by dowloading the habana artifactory key, adding the artifactory repository to the sources list, and installing the habanalabs-container-runtime package
+        - name: Download Habana artifactory key
+          get_url:
+            url: https://vault.habana.ai/artifactory/api/gpg/key/public
+            dest: /tmp/habana-artifactory-key
+          register: install_result
+        - name: Add Habana artifactory repository to sources list
+          copy:
+            content: |
+              deb https://vault.habana.ai/artifactory/debian jammy main
+            dest: /etc/apt/sources.list.d/artifactory.list
+          register: install_result
+        - name: Add Habana artifactory key
+          shell: apt-key add /tmp/habana-artifactory-key
+          register: install_result
+        - name: Install Habana Container Runtime
+          apt:
+            name: habanalabs-container-runtime
+            state: present
+            update_cache: true
+          register: install_result
+        - name: Add Habana Container Runtime to the docker daemon.json
+          copy:
+            content: |
+              {
+              "runtimes": {
+                "habana": {
+                    "path": "/usr/bin/habana-container-runtime",
+                    "runtimeArgs": []
+                  }
+                }
+              }
+            dest: /etc/docker/daemon.json
+          register: install_result
+        - name: Restart docker service
+          service:
+            name: docker
+            state: restarted
+          register: install_result
+      when: missing_packages | length > 0
+
+
+
+    # Update Habana Stack if already installed
+    - name: Update packages if any are not up to date
+      shell: {{ habana_installer }} upgrade -t all
+      when: upgradable_packages | length > 0
+      register: update_result
+
+    ## Will do the firmware update each time.
+    ## Future versions: Need to add check here to see if firmware needs to be updated
+    ## Will unload the drivers, update the SPI firmware and then reload the drivers
+
+
 
 
     - name: SPI Firmware Update
@@ -212,12 +218,12 @@
             name: "{{ item }}"
             state: absent
           loop: "{{ habana_drivers | reverse | list }}"
-        # - name: Upgrading Habana SPI Firmware
-        #   shell: /usr/sbin/hl-fw-loader -y
-        #   register: command_result
-        # - name: Display command output
-        #   debug:
-        #     var: command_result.stdout_lines
+        - name: Upgrading Habana SPI Firmware
+          shell: /usr/sbin/hl-fw-loader -y
+          register: command_result
+        - name: Display command output
+          debug:
+            var: command_result.stdout_lines
         - name: Reload Habana drivers
           modprobe:
             name: "{{ item }}"
@@ -238,4 +244,4 @@
 
     # Always pull the latest Gaudi pytorch container from Habana Labs 
     - name: Pull the latest Gaudi pytorch container
-      shell: docker pull vault.habana.ai/gaudi-docker/1.17.1/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest
+      shell: docker pull vault.habana.ai/gaudi-docker/{{ habana_version }}/ubuntu22.04/habanalabs/pytorch-installer-2.4.0:latest


### PR DESCRIPTION
Adding in the Bare Metal Recipe for Gaudi SW stack 1.18.0 for Ubuntu.
Now checks to see if the SPI FW needs to be updated.
Updated logic in the rest of the playbook.
Updated versions of various software to support 1.18.0.