### PR TITLE
Doc Update - update Ansible Key installation instruction to be consistent with Ansible documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ override.tf.json
 .editorconfig
 .header.md
 .vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+UBUNTU_CODENAME=jammy
+wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
 sudo apt update
 
 # Install Ansible

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The primary goal of Intel Cloud Optimized Modules for Ansible is to simplify and
 
 Some examples of technologies that can be enabled and optimized are:
 
-- OPEA - Open Platform for AI[LINK](https://opea.dev/)
+- OPEA - [Open Platform for Enterprise AI](https://opea.dev/)
 - RAG - Retrieval Augmented Generation
-- Intel Guadi AI Accelerator
+- Intel Gaudi AI Accelerator
 - OneAPI AI Training and Inference with Intel® Advanced Matrix Extensions (Intel® AMX)
 - Intel AMX - Advanced Matrix Extensions
 - Intel SGX - Software Guard Extensions

--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ You will only need git and Ansible installed on your development environment. Fo
 For example, on Ubuntu:
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-sudo apt update
 sudo apt install git -y
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 sudo apt install ansible -y
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,9 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 # Install Git 
 sudo apt install git -y
 
-# Install Ansible Key
-UBUNTU_CODENAME=jammy
-wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
-sudo apt update
+# Install Ansible Key (Ubuntu), see ansible installation guide above for other distros.
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For example, on Ubuntu by using [ansible-pull](https://docs.ansible.com/ansible/
 sudo apt install git -y
 
 # Install Ansible Key (Ubuntu), see ansible installation guide above for other distros.
+sudo apt update
 sudo apt install software-properties-common
 sudo add-apt-repository --yes --update ppa:ansible/ansible
 

--- a/recipes/ai-fastchat-amx-ubuntu/README.md
+++ b/recipes/ai-fastchat-amx-ubuntu/README.md
@@ -46,8 +46,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y
@@ -83,8 +84,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-gaudi-ubuntu/README.md
+++ b/recipes/ai-gaudi-ubuntu/README.md
@@ -46,8 +46,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-oneapi_ai_toolkit-amx-ubuntu/README.md
+++ b/recipes/ai-oneapi_ai_toolkit-amx-ubuntu/README.md
@@ -45,8 +45,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-opea-chatqna-gaudi/README.md
+++ b/recipes/ai-opea-chatqna-gaudi/README.md
@@ -41,8 +41,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-opea-chatqna-xeon-falcon11B/README.md
+++ b/recipes/ai-opea-chatqna-xeon-falcon11B/README.md
@@ -48,8 +48,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-opea-chatqna-xeon/README.md
+++ b/recipes/ai-opea-chatqna-xeon/README.md
@@ -41,8 +41,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-opea-codegen-xeon/README.md
+++ b/recipes/ai-opea-codegen-xeon/README.md
@@ -41,8 +41,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-pytorch-amx-ubuntu/README.md
+++ b/recipes/ai-pytorch-amx-ubuntu/README.md
@@ -44,8 +44,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-pytorch-sgx-ubuntu/README.MD
+++ b/recipes/ai-pytorch-sgx-ubuntu/README.MD
@@ -43,8 +43,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y

--- a/recipes/ai-stable_diffusion-amx-ubuntu/README.md
+++ b/recipes/ai-stable_diffusion-amx-ubuntu/README.md
@@ -46,8 +46,9 @@ For example, on Ubuntu:
 sudo apt install git -y
 
 # Install Ansible Key
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository --yes --update ppa:ansible/ansible
 
 # Install Ansible
 sudo apt install ansible -y


### PR DESCRIPTION
Addressing documentaiton Issue #53, the Ansible Ubuntu installation instructions are updated and deprecated the use of `apt-key add`. This PR updates the README's in the project to reflect this update.
